### PR TITLE
fix: return 422 for invalid tags_match values

### DIFF
--- a/marketplace/plugins_market/schemas/plugin.py
+++ b/marketplace/plugins_market/schemas/plugin.py
@@ -294,7 +294,10 @@ class PluginListQuery(BaseModel):
             f"参数长度上限 {QUERY_TAGS_MAX_LEN} 字符，超出返回 422"
         ),
     )
-    tags_match: str = Field("all", description="标签匹配模式: all=同时包含全部标签, any=包含任一标签")
+    tags_match: Literal["all", "any"] = Field(
+        "all",
+        description="标签匹配模式: all=同时包含全部标签, any=包含任一标签",
+    )
     order_by: str = Field(
         "install_count",
         description=(
@@ -343,10 +346,9 @@ class PluginListQuery(BaseModel):
     @field_validator("tags_match", mode="before")
     @classmethod
     def normalize_tags_match(cls, v: object) -> str:
-        s = str(v or "all").strip().lower()
-        if s not in ("all", "any"):
-            raise ValueError("tags_match must be one of: all, any")
-        return s
+        # Normalize accepted values here and let Literal produce the standard
+        # validation error for unsupported values.
+        return str(v or "all").strip().lower()
 
 
 class TagOption(BaseModel):

--- a/marketplace/plugins_market/tests/test_tag_filter.py
+++ b/marketplace/plugins_market/tests/test_tag_filter.py
@@ -286,6 +286,39 @@ def test_tags_match_query_validation():
         PluginListQuery(tags="python", tags_match="maybe")
 
 
+def test_tags_match_invalid_query_returns_422():
+    """非法 tags_match 通过 FastAPI 查询参数解析时应返回 422，而不是 500。"""
+    from typing import Annotated
+
+    from fastapi import FastAPI, Query
+    from fastapi.testclient import TestClient
+
+    from plugins_market.core.http_error_logging import register_exception_handlers
+    from plugins_market.core.logging import get_logger
+
+    app = FastAPI()
+
+    @app.get("/plugins")
+    def list_plugins(query: Annotated[PluginListQuery, Query()]):
+        return {"tags_match": query.tags_match}
+
+    register_exception_handlers(app, logger=get_logger("test_tag_match_validation"))
+    client = TestClient(app, raise_server_exceptions=False)
+
+    response = client.get("/plugins?tags=python&tags_match=invalid")
+
+    assert response.status_code == 422
+    body = response.json()
+    assert body["detail"]["error"] == "validation_error"
+    assert body["detail"]["error_code"] == "SKILLHUB_VALIDATION_FAILED"
+    assert any(detail["loc"][-1] == "tags_match" for detail in body["detail"]["details"])
+
+    # Case-insensitive compatibility remains supported for valid values.
+    valid_response = client.get("/plugins?tags=python&tags_match=ANY")
+    assert valid_response.status_code == 200
+    assert valid_response.json() == {"tags_match": "any"}
+
+
 def test_retrieval_path_ignores_tags_when_keyword_present(monkeypatch):
     """搜索时不感知 tags：检索路径返回混合标签/无标签资产，不做标签过滤。
 
@@ -838,4 +871,3 @@ def test_recommend_path_with_tags_falls_back_to_db(monkeypatch):
     resp = list_plugins_service(query, db, None, viewer=_viewer(user_id="u1"))
     # install_count 降序：s2(9) 在前；推荐未被调用
     assert [it.asset_id for it in resp.items] == ["s2", "s1"]
-


### PR DESCRIPTION
/kind bug

Fixes #92

## Summary
- Constrain `PluginListQuery.tags_match` to the supported `all` and `any` values.
- Preserve case-insensitive normalization for valid values.
- Add an HTTP-level regression test proving invalid values return 422 instead of 500.

## Testing
- `python -m compileall` passed for the changed modules.
- Pydantic validation checks passed.
- Full pytest was not run because dependency installation timed out in the execution environment.