### PR TITLE
fix(import): report identical asset reuse as skipped

### DIFF
--- a/marketplace/plugins_market/imports/skill_import_service.py
+++ b/marketplace/plugins_market/imports/skill_import_service.py
@@ -380,10 +380,11 @@ def skill_import_from_staging_dir(
                     asset_type=pr.asset_type,
                     plugin_type=pr.plugin_type,
                 )
+            is_skipped = pr._import_disposition == "skipped"
             results.append(
                 item_result_model(
                     entry=entry_name,
-                    status="ok",
+                    status="skipped" if is_skipped else "ok",
                     plugin_id=pr.plugin_id,
                     name=pr.name,
                     version=pr.version,
@@ -392,7 +393,7 @@ def skill_import_from_staging_dir(
             )
             _log_skill_import_entry(
                 stage="entry_complete",
-                result="success",
+                result="skipped" if is_skipped else "success",
                 entry=entry_name,
                 resource_type=(pr.asset_type or "plugin") if allow_multi_asset else "skill",
                 resource_id=pr.plugin_id,

--- a/marketplace/plugins_market/schemas/plugin.py
+++ b/marketplace/plugins_market/schemas/plugin.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Literal, List, Optional
 
 from fastapi import UploadFile
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, PrivateAttr, field_validator
 
 from plugins_market.validation.constants import QUERY_TAGS_MAX_LEN
 
@@ -64,6 +64,7 @@ class PluginPublishResult(BaseModel):
     plugin_type: Optional[str] = None
     publish_result: Optional[str] = None
     visibility: Optional[str] = None
+    _import_disposition: str = PrivateAttr(default="published")
 
 
 @dataclass

--- a/marketplace/plugins_market/services/plugin.py
+++ b/marketplace/plugins_market/services/plugin.py
@@ -917,7 +917,9 @@ def publish(
             asset_id,
             version,
         )
-        return _make_publish_result(asset_for_result, existing_version, zip_key)
+        result = _make_publish_result(asset_for_result, existing_version, zip_key)
+        result._import_disposition = "skipped"
+        return result
 
     if existing_version and not force:
         raise PublishError(

--- a/marketplace/plugins_market/tests/test_multi_asset_import.py
+++ b/marketplace/plugins_market/tests/test_multi_asset_import.py
@@ -340,6 +340,42 @@ def test_mixed_asset_collection_returns_precise_types_and_uses_system_token(
     assert all(call["is_system_token"] is True for call in calls)
 
 
+def test_asset_import_reports_idempotent_reuse_as_skipped_with_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_raw_agent_plugin(tmp_path / "wellness-plugin")
+
+    def fake_publish(**kwargs: object) -> PluginPublishResult:
+        result = _fake_publish_result(kwargs["content"])  # type: ignore[arg-type]
+        object.__setattr__(result, "_import_disposition", "skipped")
+        return result
+
+    monkeypatch.setattr("plugins_market.imports.skill_import_service.publish", fake_publish)
+    result = skill_import_from_staging_dir(
+        tmp_path,
+        user_id="system_admin",
+        db=SimpleNamespace(rollback=lambda: None),
+        storage=SimpleNamespace(),
+        is_system_token=True,
+        publisher_name_override="system_admin",
+        allow_multi_asset=True,
+    )
+
+    assert result.summary.model_dump() == {"total": 1, "ok": 0, "failed": 0, "skipped": 1}
+    assert result.results[0].model_dump() == {
+        "entry": "wellness-plugin",
+        "status": "skipped",
+        "plugin_id": "id-wellness-plugin",
+        "name": "wellness-plugin",
+        "version": "1.0.0",
+        "error": None,
+        "message": None,
+        "asset_id": "id-wellness-plugin",
+        "asset_type": "agent-plugin",
+        "plugin_type": "agent-plugin",
+    }
+
+
 def test_mcp_builtin_index_supplies_per_asset_market_metadata(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Paired: [GitHub #109](https://github.com/openJiuwen-ai/skillhub/pull/109) ↔ [GitCode !239](https://gitcode.com/openJiuwen/skillhub/merge_requests/239)

/kind bug

### What this PR does / why we need it

Batch asset imports previously counted an identical same-version artifact as a successful publish, even though the publish path reused the existing asset without creating a version. This made the item-level status and summary inaccurate.

This change carries a private, non-serialized import disposition on the publish result. The import service reports a side-effect-free idempotent reuse as `skipped`, while preserving the existing asset identity. A retry that restarts system review still reports `ok` because it changes state.

### Which issue(s) this PR fixes

Fixes #101

### Verification

- `pytest -q marketplace/plugins_market/tests/test_multi_asset_import.py`
- 22 passed

### Compatibility

- No public response schema fields are added or removed.
- New publishes and review-restart retries keep their existing `ok` behavior.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #101
<!-- /bot1-related-issues -->
