### PR TITLE
docs: 修正推荐系统运维指南中一处失效的相对链接

### DIFF
--- a/docs/zh/6. 运维指南/可选能力/推荐系统/README.md
+++ b/docs/zh/6. 运维指南/可选能力/推荐系统/README.md
@@ -190,7 +190,7 @@ python -m recommender.offline.redis_sync
 
 ## 运维关注点
 
-- Redis / Milvus 网络可达（容器或跨机部署时注意主机名与端口）。Windows + WSL Docker：marketplace 在 Windows 时 `MILVUS_HOST` 用 WSL 网卡 IP（`hostname -I` / `start_milvus.ps1` 输出）；WSL 休眠后容器会没了，表现为推荐接口空等数秒再兜底。本地部署见仓库根目录 `tools/milvus/本地容器化部署.md`。华为云 DCS 见[配置切换-Redis_DCS 与 MinIO_OBS](../../配置切换-Redis_DCS与MinIO_OBS.md)。
+- Redis / Milvus 网络可达（容器或跨机部署时注意主机名与端口）。Windows + WSL Docker：marketplace 在 Windows 时 `MILVUS_HOST` 用 WSL 网卡 IP（`hostname -I` / `start_milvus.ps1` 输出）；WSL 休眠后容器会没了，表现为推荐接口空等数秒再兜底。本地部署见仓库根目录 `tools/milvus/本地容器化部署.md`。华为云 DCS 见[配置切换-Redis_DCS 与 MinIO_OBS](../../../配置切换-Redis_DCS与MinIO_OBS.md)。
 - Milvus 若开启 `authorizationEnabled`，须配置 `MILVUS_USER` / `MILVUS_PASSWORD`（默认内置多为 `root`/`Milvus`，生产改密）；密码支持 `SecurityUtils` 密文。未开鉴权时这两项留空即可。
 - Embedding API 配额与维度一致性；换模型维度或 schema 升级后必须 `--mode full`。
 - 首次启用建议临时 `MARKET_REC_REBUILD_ON_STARTUP=true`，并确保下载目录已有 zip（或先手动 `package_sync`）。日志出现 `recommender job: redis_sync done` 且 milvus upsert 成功后，可改回 `false` 以免每次发版都全量重建。


### PR DESCRIPTION
Paired: [GitHub #118](https://github.com/openJiuwen-ai/skillhub/pull/118) ↔ [GitCode !245](https://gitcode.com/openJiuwen/skillhub/merge_requests/245)

## 问题 / Problem

`docs/zh/6. 运维指南/可选能力/推荐系统/README.md:193` 里指向配置切换文档的相对链接少了一级，点击后 404：

```diff
- 华为云 DCS 见[配置切换-Redis_DCS 与 MinIO_OBS](../../配置切换-Redis_DCS与MinIO_OBS.md)。
+ 华为云 DCS 见[配置切换-Redis_DCS 与 MinIO_OBS](../../../配置切换-Redis_DCS与MinIO_OBS.md)。
```

该文件位于 `docs/zh/` 下三级（`6. 运维指南/可选能力/推荐系统/`），而 `../../` 只回到 `docs/zh/6. 运维指南/`：

| 写法 | 解析结果 | 是否存在 |
| --- | --- | --- |
| `../../配置切换-Redis_DCS与MinIO_OBS.md` | `docs/zh/6. 运维指南/配置切换-Redis_DCS与MinIO_OBS.md` | ❌ |
| `../../../配置切换-Redis_DCS与MinIO_OBS.md` | `docs/zh/配置切换-Redis_DCS与MinIO_OBS.md` | ✅ |

## 目标文件无歧义 / The intended target is unambiguous

全仓库只有这一个 `配置切换-Redis_DCS与MinIO_OBS.md`，就在 `docs/zh/` 下。另外，同一篇推荐系统文档的开发指南版本 `docs/zh/5. 开发指南/推荐系统/README.md:94,264` 链接的正是这个目标——它只有一级 `6./5.` 的差异，所以那里写 `../../` 是对的。这也反过来印证了运维指南这篇应该多一级。

## 验证 / Verification

```bash
# 修改前后的解析结果（基于 develop 快照，与远端 blob bf92b894 逐字节一致）
old target exists: false
new target exists: true
changed lines: 1     # 仅第 193 行
```

改动 `+1 / -1`，纯文档、单行。skillhub 的 `docs/` 目前只有 `zh` 一套，无对应英文文档需同步。
